### PR TITLE
String escaping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class PyTest(Command):
 
 setup(
     name='XlsxWriter',
-    version='0.9.1.1',
+    version='0.9.1.2',
     author='John McNamara',
     author_email='jmcnamara@cpan.org',
     url='https://github.com/brucehappy/XlsxWriter',

--- a/xlsxwriter/__init__.py
+++ b/xlsxwriter/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.9.1'
+__version__ = '0.9.1.2'
 __VERSION__ = __version__
 from .workbook import Workbook

--- a/xlsxwriter/sharedstrings.py
+++ b/xlsxwriter/sharedstrings.py
@@ -10,6 +10,7 @@ import re
 
 # Package imports.
 from . import xmlwriter
+from .utility import escape_string
 
 
 class SharedStrings(xmlwriter.XMLwriter):
@@ -86,18 +87,8 @@ class SharedStrings(xmlwriter.XMLwriter):
         # Write the <si> element.
         attributes = []
 
-        # Excel escapes control characters with _xHHHH_ and also escapes any
-        # literal strings of that type by encoding the leading underscore.
-        # So "\0" -> _x0000_ and "_x0000_" -> _x005F_x0000_.
-        # The following substitutions deal with those cases.
-
-        # Escape the escape.
-        string = re.sub('(_x[0-9a-fA-F]{4}_)', r'_x005F\1', string)
-
-        # Convert control character to the _xHHHH_ escape.
-        string = re.sub(r'([\x00-\x08\x0B-\x1F])',
-                        lambda match: "_x%04X_" %
-                        ord(match.group(1)), string)
+        # Escape the string.
+        string = escape_string(string)
 
         # Add attribute to preserve leading or trailing whitespace.
         if re.search('^\s', string) or re.search('\s$', string):

--- a/xlsxwriter/utility.py
+++ b/xlsxwriter/utility.py
@@ -10,6 +10,29 @@ from warnings import warn
 
 COL_NAMES = {}
 range_parts = re.compile(r'(\$?)([A-Z]{1,3})(\$?)(\d+)')
+escape_escape = re.compile('(_x[0-9a-fA-F]{4}_)')
+# Include all characters which are not in the valid ranges for XML 1.0
+escape_control = re.compile(u'([^\u0009\u000A\u000D\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF])')
+
+
+def escape_string(str):
+    """
+    Excel escapes control characters with _xHHHH_ and also escapes any
+    literal strings of that type by encoding the leading underscore.
+    So "\0" -> _x0000_ and "_x0000_" -> _x005F_x0000_.
+    The following substitutions deal with those cases.
+
+    Args:
+       str: The string
+
+    Returns:
+       The escaped string
+
+    """
+    str = re.sub(escape_escape, r'_x005F\1', str)
+    return re.sub(escape_control,
+                  lambda match: "_x%04X_" %
+                  ord(match.group(1)), str)
 
 
 def xl_rowcol_to_cell(row, col, row_abs=False, col_abs=False):

--- a/xlsxwriter/worksheet.py
+++ b/xlsxwriter/worksheet.py
@@ -26,6 +26,7 @@ from .format import Format
 from .drawing import Drawing
 from .shape import Shape
 from .xmlwriter import XMLwriter
+from .utility import escape_string
 from .utility import xl_rowcol_to_cell
 from .utility import xl_rowcol_to_cell_fast
 from .utility import xl_cell_to_rowcol
@@ -5303,11 +5304,8 @@ class Worksheet(xmlwriter.XMLwriter):
             else:
                 # Write an optimized in-line string.
 
-                # Escape control characters. See SharedString.pm for details.
-                string = re.sub('(_x[0-9a-fA-F]{4}_)', r'_x005F\1', string)
-                string = re.sub(r'([\x00-\x08\x0B-\x1F])',
-                                lambda match: "_x%04X_" %
-                                ord(match.group(1)), string)
+                # Escape the string
+                string = escape_string(string)
 
                 # Write any rich strings without further tags.
                 if re.search('^<r>', string) and re.search('</r>$', string):


### PR DESCRIPTION
Moved escaping of strings into a utility function instead of being copied in two places (inline and shared string output).  Changed the function to cover all of the characters that are not allowed in XML 1.0 instead of just those in low ASCII.  Specifically this handles U+FFFF.  Upped the version number.